### PR TITLE
Added error messaging to auth modals

### DIFF
--- a/assets/scripts/auth/events.js
+++ b/assets/scripts/auth/events.js
@@ -32,6 +32,7 @@ const onChangePassword = function (event) {
   console.log('change pass click is heard')
   event.preventDefault()
   const data = getFormFields(event.target)
+  console.log('data is', data)
   api.changePassword(data)
     .then(ui.changePasswordSuccess)
     .catch(ui.changePasswordFailure)

--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -28,6 +28,7 @@ const signUpFailure = (error) => {
   $('#sign-up-email').val('')
   $('#sign-up-password').val('')
   $('#sign-up-password-confirmation').val('')
+  $('#sign-up-error').text('You may have entered invalid credentials, please try again.')
   // $('#sign-up-status').show()
 }
 
@@ -46,6 +47,7 @@ const signInFailure = (error) => {
   console.log('sign in fail')
   $('#sign-in-email').val('')
   $('#sign-in-password').val('')
+  $('#sign-in-error').text('You may have entered invalid credentials, please try again.')
   console.log(error)
   // $('#sign-in-status').show()
 }
@@ -76,6 +78,7 @@ const changePasswordSuccess = (data) => {
 
 const changePasswordFailure = (error) => {
   console.log('change pass fail')
+  $('#change-password-failure').text('You may have an invalid password, please try again.')
   console.log(error)
 }
 

--- a/index.html
+++ b/index.html
@@ -86,7 +86,6 @@
 
         <!-- Sign-in Modal Body -->
         <div class="modal-body">
-
           <form id="sign-in" role="form">
             <div class="form-group">
               <label for="sign-in-email">Email address</label>
@@ -99,7 +98,7 @@
             <!-- <button type="submit" class="btn btn-default">Submit</button> -->
             <input type="submit" class="btn btn-default" value="Sign-in" name="submit">
             <div id="sign-in-status" class="auth-status">
-              <span><p>Sign-in error, try again!</p></span>
+              <p id="sign-in-error"></p>
             </div>
           </form>
         </div>
@@ -150,7 +149,7 @@
         <!-- <button type="submit" class="btn btn-default">Submit</button> -->
         <input type="submit" class="btn btn-default" name="submit" value="Create Account">
         <div id="sign-up-status" class="auth-status">
-          <span><p>Sign-up error, try again!</p></span>
+          <p id="sign-up-error"></p>
         </div>
         </form>
       </div>
@@ -181,17 +180,17 @@
             <div class="form-group">
             </div>
             <div class="form-group">
-              <label for="change-password-password">Password</label>
+              <label for="change-password-password">Old Password</label>
               <input type="password" class="form-control" name="passwords[old]" id="old-password" placeholder="Old Password" />
             </div>
             <div class="form-group">
-              <label for="change-password-password-confirmation">Password</label>
+              <label for="change-password-password-confirmation">New Password</label>
               <input type="password" class="form-control" name="passwords[new]" id="new-password" placeholder="New Password" />
             </div>
             <!-- <button type="submit" class="btn btn-default">Submit</button> -->
             <input type="submit" class="btn btn-default" name="submit" value="Change Password">
             <div id="change-password-status" class="auth-status">
-              <span><p>Change password error, try again!</p></span>
+              <p id="change-password-failure"></p>
             </div>
           </form>
         </div>


### PR DESCRIPTION
For sign up, sign in, and change password modals, added a <p>
at the bottom of the modal that is populated with error
message by jquery calls in ui failure functions if any
of those experience failures to notify user of issue. Also
changed title of password modal fields.